### PR TITLE
Prevent type confusion through parameter tampering

### DIFF
--- a/lib/commitHandler.js
+++ b/lib/commitHandler.js
@@ -51,6 +51,9 @@ function createMiddleware(options) {
     let repo;
     let walker;
 
+    if (typeof fpath !== 'string') {
+      res.status(400).send(`Bad request`);
+    }
     // issue #247: lenient handling of redundant leading slashes in path
     while (fpath.length && fpath[0] === '/') {
       // trim leading slash

--- a/lib/commitHandler.js
+++ b/lib/commitHandler.js
@@ -52,7 +52,7 @@ function createMiddleware(options) {
     let walker;
 
     if (typeof fpath !== 'string') {
-      res.status(400).send(`Bad request`);
+      res.status(400).send('Bad request');
     }
     // issue #247: lenient handling of redundant leading slashes in path
     while (fpath.length && fpath[0] === '/') {


### PR DESCRIPTION
The `fpath` parameter can be manipulated by passing it multiple times:

https://lgtm.com/projects/g/adobe/git-server/alerts/?mode=tree&ruleFocus=1506301137371
https://lgtm.com/rules/1506301137371/