### PR TITLE
feat(server): add option to specify listener for raw requests

### DIFF
--- a/lib/rawHandler.js
+++ b/lib/rawHandler.js
@@ -63,6 +63,15 @@ function createMiddleware(options) {
       fpath = fpath.substr(1);
     }
 
+    if (options.onRawRequest && typeof options.onRawRequest === 'function') {
+      options.onRawRequest({
+        req,
+        repoPath: repPath,
+        filePath: fpath,
+        ref: refName,
+      });
+    }
+
     // project-helix/#187: serve modified content only if the requested ref is currently checked out
     isCheckedOut(repPath, refName)
       .then((serveUncommitted) => resolveBlob(repPath, refName, fpath, serveUncommitted))

--- a/lib/rawHandler.js
+++ b/lib/rawHandler.js
@@ -64,12 +64,16 @@ function createMiddleware(options) {
     }
 
     if (options.onRawRequest && typeof options.onRawRequest === 'function') {
-      options.onRawRequest({
-        req,
-        repoPath: repPath,
-        filePath: fpath,
-        ref: refName,
-      });
+      try {
+        options.onRawRequest({
+          req,
+          repoPath: repPath,
+          filePath: fpath,
+          ref: refName,
+        });
+      } catch {
+        // ignore errors from listener
+      }
     }
 
     // project-helix/#187: serve modified content only if the requested ref is currently checked out

--- a/lib/rawHandler.js
+++ b/lib/rawHandler.js
@@ -67,8 +67,8 @@ function createMiddleware(options) {
       try {
         options.onRawRequest({
           req,
-          repoPath: repPath,
-          filePath: fpath,
+          repoPath: path.normalize(repPath),
+          filePath: path.normalize(fpath),
           ref: refName,
         });
       } catch {


### PR DESCRIPTION
This PR adds the ability to specify a listener when request to the raw handler are issued.
