### PR TITLE
fix(utils): sanitize owner and repo name

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,6 +18,8 @@ const path = require('path');
 
 const fse = require('fs-extra');
 
+const UNSAFE_GIT_NAME_CHARS_RE = /[^A-Za-z0-9_.-]/g;
+
 /**
  * Resolves the file system path of the specified repository.
  *
@@ -26,7 +28,22 @@ const fse = require('fs-extra');
  * @param {string} repo repository name
  */
 function resolveRepositoryPath(options, owner, repo) {
-  let repPath = path.resolve(options.repoRoot, owner, repo);
+  // GitHub Security Lab (GHSL) Vulnerability Report: GHSL-2020-133
+  // sanitize owner and repo which are typically extracted
+  // from a user entered url and are potentially unsafe to use
+  // in fs paths (e.g. ../.. etc)
+  const sanitize = (s) => {
+    switch (s) {
+      case '.':
+      case '..':
+        // '.' is a safe character in a git name but
+        // '.' and '..' aren't valid git names
+        return s.replace(/./g, '-');
+      default:
+        return s.replace(UNSAFE_GIT_NAME_CHARS_RE, '-');
+    }
+  };
+  let repPath = path.resolve(options.repoRoot, sanitize(owner), sanitize(repo));
 
   if (options.virtualRepos[owner] && options.virtualRepos[owner][repo]) {
     repPath = path.resolve(options.virtualRepos[owner][repo].path);

--- a/test/utils_tests.js
+++ b/test/utils_tests.js
@@ -18,6 +18,7 @@ const assert = require('assert');
 
 const {
   pathExists,
+  resolveRepositoryPath,
 } = require('../lib/utils');
 
 describe('Testing utils.js', () => {
@@ -25,5 +26,16 @@ describe('Testing utils.js', () => {
     const { dir, base } = path.parse(__filename);
     assert.ok(await pathExists(dir, base));
     assert.ok(!await pathExists(dir, base.toUpperCase()));
+  });
+
+  it('resolveRepositoryPath sanitizes owner and repo name', async () => {
+    const repoRoot = path.resolve('.');
+    const options = { repoRoot, virtualRepos: {} };
+    let p = resolveRepositoryPath(options, 'owner', 'repo');
+    assert.ok(p.startsWith(repoRoot));
+    p = resolveRepositoryPath(options, '../..', '.');
+    assert.ok(p.startsWith(repoRoot));
+    p = resolveRepositoryPath(options, 'foo/..', 'bar/.');
+    assert.ok(p.startsWith(repoRoot));
   });
 });


### PR DESCRIPTION
GitHub Security Lab (GHSL) Vulnerability Report: GHSL-2020-133

owner and repo name specified in url are potentially unsafe to use in fs paths and need to be
sanitized.

